### PR TITLE
Exchange Public Token for Access Token

### DIFF
--- a/backend/api/plaidRoutes.js
+++ b/backend/api/plaidRoutes.js
@@ -23,4 +23,26 @@ router.post("/create_link_token", verifyFirebaseToken, async (req, res) => {
   }
 });
 
+router.post("/exchange_public_token", verifyFirebaseToken, async (req, res) => {
+  const { public_token } = req.body;
+
+  if (!public_token) {
+    return res.status(400).json({ error: "Missing public_token" });
+  }
+
+  try {
+    const response = await plaidClient.itemPublicTokenExchange({
+      public_token,
+    });
+
+    const access_token = response.data.access_token;
+    const item_id = response.data.item_id;
+
+    res.json({ access_token, item_id });
+  } catch (err) {
+    console.error("Token exchange failed:", err.response?.data || err.message);
+    res.status(500).json({ error: "Token exchange failed" });
+  }
+});
+
 module.exports = router;


### PR DESCRIPTION
## Description
- Creates an API to exchange the generated public token for an access token.
- Later PRs will be used in frontend to exchange public token for an access token.
## Milestone
- Milestone 2, [Issue 6](https://github.com/NancyMetaU/FinanceCompanion/issues/6)
## Resources
- [Plaid QuickStart Documentation](https://plaid.com/docs/quickstart/#quickstart-setup)
## Test Plan
- Hit exchange api with public token body and auth header (http://localhost:3000/api/exchange_public_token) -> returns access_token and item_id.