### PR TITLE
Add Fetch Access Token API to Frontend

### DIFF
--- a/frontend/src/components/PlaidLinkButton.jsx
+++ b/frontend/src/components/PlaidLinkButton.jsx
@@ -29,8 +29,20 @@ const PlaidLinkButton = () => {
     fetchLinkToken();
   }, []);
 
-  const onSuccess = (public_token, metadata) => {
-    // TO DO - call backend to exchange public_token for access_token
+  const onSuccess = async (public_token, metadata) => {
+    const user = getAuth().currentUser;
+    const idToken = await user.getIdToken();
+
+    const res = await fetch(`${BACKEND_URL}/api/exchange_public_token`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${idToken}`,
+      },
+      body: JSON.stringify({ public_token }),
+    });
+
+    const data = await res.json();
   };
 
   const { open, ready } = usePlaidLink({


### PR DESCRIPTION
## Description
- Add a fetch exchange public token for access token API to onSuccess function in frontend.
- Later PRs will save this access token to DB in backend.
## Milestone
- Milestone 2, [Issue 6](https://github.com/NancyMetaU/FinanceCompanion/issues/6)
## Resources
- [Plaid React SDK – react-plaid-link](https://github.com/plaid/react-plaid-link/blob/master/examples/component.tsx)
## Test Plan
- After inputting bank info into Plaid UI, success UI appears.