### PR TITLE
Add News Mock Data to Frontend

### DIFF
--- a/frontend/src/mock/newsData.json
+++ b/frontend/src/mock/newsData.json
@@ -1,0 +1,114 @@
+[
+	{
+		"uuid": "69b15807-469a-4f2d-90ac-d15472204e30",
+		"title": "Tesla: Another Miss, Another Rally - We’re Still Buying Ahead Of Q2 (NASDAQ:TSLA)",
+		"description": "Tesla, Inc.'s Q2 deliveries missed targets, but low expectations and Musk-driven sentiment keep the stock strong. Click for our TSLA update and earnings preview.",
+		"keywords": "",
+		"snippet": "Don’t just invest—dominate with Tech Contrarians' realized return on closed positions of 65.8% since inception. You’ll get exclusive insights into high-fo...",
+		"url": "https://seekingalpha.com/article/4798941-tesla-another-miss-another-rally-were-still-buying-ahead-of-q2",
+		"image_url": "https://static.seekingalpha.com/cdn/s3/uploads/getty_images/2171333579/image_2171333579.jpg?io=getty-c-w1536",
+		"language": "en",
+		"published_at": "2025-07-02T19:00:58.000000Z",
+		"source": "seekingalpha.com",
+		"relevance_score": null,
+		"entities": [
+			{
+				"symbol": "TSLA",
+				"name": "Tesla, Inc.",
+				"exchange": null,
+				"exchange_long": null,
+				"country": "us",
+				"type": "equity",
+				"industry": "Consumer Cyclical",
+				"match_score": 80.707054,
+				"sentiment_score": -0.21315,
+				"highlights": [
+					{
+						"highlight": "<em>Tesla</em>, <em>Inc</em>. (<em>NASDA[+134 characters]",
+						"sentiment": -0.2732,
+						"highlighted_in": "main_text"
+					},
+					{
+						"highlight": "<em>Tesla</em>: Another Miss, Another Rally - We’re Still Buying Ahead Of Q2 (<em>NASDAQ:TSLA</em>)",
+						"sentiment": -0.1531,
+						"highlighted_in": "title"
+					}
+				]
+			}
+		],
+		"similar": []
+	},
+	{
+		"uuid": "3b64a10e-6858-4734-a5f8-51b20b106b2c",
+		"title": "Tesla's Deliveries Report: A Major Miss (Rating Upgrade) (NASDAQ:TSLA)",
+		"description": "Tesla stock rallied after the release came out, maybe because retail investors had different expectations than Wall Street firms. Find out why TSLA is a Hold.",
+		"keywords": "",
+		"snippet": "Tesla, Inc. (NASDAQ: TSLA ) releases its second quarter earnings on July 23 . Heading into the release, we already have strong indications that the company will...",
+		"url": "https://seekingalpha.com/article/4798938-tesla-deliveries-report-a-major-miss-rating-upgrade",
+		"image_url": "https://static.seekingalpha.com/cdn/s3/uploads/getty_images/2217857584/image_2217857584.jpg?io=getty-c-w1536",
+		"language": "en",
+		"published_at": "2025-07-02T18:58:05.000000Z",
+		"source": "seekingalpha.com",
+		"relevance_score": null,
+		"entities": [
+			{
+				"symbol": "TSLA",
+				"name": "Tesla, Inc.",
+				"exchange": null,
+				"exchange_long": null,
+				"country": "us",
+				"type": "equity",
+				"industry": "Consumer Cyclical",
+				"match_score": 72.741714,
+				"sentiment_score": 0,
+				"highlights": [
+					{
+						"highlight": "<em>Tesla</em>, <em>Inc</em>. (<em>NASDA[+189 characters]",
+						"sentiment": 0.1531,
+						"highlighted_in": "main_text"
+					},
+					{
+						"highlight": "Tesla's Deliveries Report: A Major Miss (Rating Upgrade) (<em>NASDAQ:TSLA</em>)",
+						"sentiment": -0.1531,
+						"highlighted_in": "title"
+					}
+				]
+			}
+		],
+		"similar": []
+	},
+	{
+		"uuid": "5336f36e-7823-4844-b04a-f271c068a9a5",
+		"title": "IDEX: Navigating Uncertainty With Steady Growth And Strong Cash Flow (NYSE:IEX)",
+		"description": "IDEX Corporation delivers steady cash flow and high margins from niche industrial markets, supported by a diversified portfolio and mission-critical products. Learn more on IEX stock here.",
+		"keywords": "",
+		"snippet": "I hold a PhD in Machine Learning focused on Economics and Finance and have academic affiliations with IESE Business School, ESADE Business School, and the Barce...",
+		"url": "https://seekingalpha.com/article/4798936-idex-navigating-uncertainty-with-steady-growth-and-strong-cash-flow",
+		"image_url": "https://static.seekingalpha.com/cdn/s3/uploads/getty_images/1488572671/image_1488572671.jpg?io=getty-c-w1536",
+		"language": "en",
+		"published_at": "2025-07-02T18:51:28.000000Z",
+		"source": "seekingalpha.com",
+		"relevance_score": null,
+		"entities": [
+			{
+				"symbol": "IEX",
+				"name": "IDEX Corporation",
+				"exchange": null,
+				"exchange_long": null,
+				"country": "us",
+				"type": "equity",
+				"industry": "Industrials",
+				"match_score": 75.5096,
+				"sentiment_score": 0.5423,
+				"highlights": [
+					{
+						"highlight": "<em>IDEX</em>: Navigating Uncertainty With Steady Growth And Strong Cash Flow (<em>NYSE:IEX</em>)",
+						"sentiment": 0.5423,
+						"highlighted_in": "title"
+					}
+				]
+			}
+		],
+		"similar": []
+	}
+]


### PR DESCRIPTION
## Description
- Adds mock data from the Marketaux API to not waste API calls (100 limit).
- Later PRs will use this mock data to display on frontend and avoid using API Call Limit.
## Milestone
- Milestone 2, [Issue 9](https://github.com/NancyMetaU/FinanceCompanion/issues/9)
## Resources
- None
## Test Plan
- None