### PR TITLE
[TC1] Fix Transaction Category Null

### DIFF
--- a/backend/services/transactionService.js
+++ b/backend/services/transactionService.js
@@ -33,7 +33,7 @@ const syncTransactions = async (userId) => {
           name: txn.name,
           amount: txn.amount,
           date: new Date(txn.date),
-          category: txn.category?.[0] || null,
+          category: txn.personal_finance_category.primary || null,
           transactionType: txn.amount >= 0 ? "debit" : "credit",
         },
       })


### PR DESCRIPTION
## Description
- Fixes deprecated category field (defaulting to null) to personal finance category 
- Uses category for budgeting 
## Milestone
- Milestone 3, [Issue 58](https://github.com/NancyMetaU/FinanceCompanion/issues/58)
## Resources
- [Plaid API Transaction Doc](https://plaid.com/docs/api/products/transactions/#categoriesget)
## Test Plan
- Upon fetch, transaction table is populated with non-null category field 