### PR TITLE
[TC 1] Add Debt Layer to Budget Creation 

### DIFF
--- a/backend/services/budgetService.js
+++ b/backend/services/budgetService.js
@@ -74,6 +74,14 @@ const adjustNeedsForRecurring = (income, needsPct, recurringTxns) => {
   };
 };
 
+const adjustBudgetForDebtPriority = (wantsPct, savingsPct, debtPriority) => {
+
+  return {
+    wantsPct: newWantsPct,
+    savingsPct: newSavingsPct,
+  };
+};
+
 const calculateBudget = async (userId) => {
   try {
     const preferences = await getUserPreferences(userId);
@@ -83,9 +91,14 @@ const calculateBudget = async (userId) => {
       throw new Error("Missing income in user preferences.");
     }
 
-    const { needsPct, wantsPct, savingsPct } = getDynamicBudgetSplit(monthlyIncome);
+    const { needsPct, wantsPct, savingsPct } =
+      getDynamicBudgetSplit(monthlyIncome);
     const recurringTxns = await getRecurringMonthlyTransactions(userId);
-    const needs = adjustNeedsForRecurring(monthlyIncome, needsPct, recurringTxns);
+    const needs = adjustNeedsForRecurring(
+      monthlyIncome,
+      needsPct,
+      recurringTxns
+    );
     const wants = { allocated: monthlyIncome * wantsPct };
     const savings = { allocated: monthlyIncome * savingsPct };
 


### PR DESCRIPTION
## Description
- This PR introduces logic to, based on your debt priority, shift the budget to help pay off debt. If debt priority is set to medium or high, we lower your wants slightly and boost savings, then split those savings so some go toward debt.
- Future PRs will add the savings priority to the budget logic.
## Milestone
- Milestone 3, [Issue 58](https://github.com/NancyMetaU/FinanceCompanion/issues/58)
## Resources
- None
## Test Plan
- Used test script to run function and confirm output.
Script:
```
const runDebtPriorityTests = () => {
  const mockRecurringTxns = [];
  const priorities = ["low", "medium", "high"];
  const income = 5000;

  priorities.forEach((priority) => {
    const mockPreferences = {
      monthlyIncome: income,
      debtPriority: priority,
    };

    const result = buildBudgetBreakdown(mockPreferences, mockRecurringTxns);

    console.log(`\n--- Debt Priority: ${priority} ---`);
    console.log("Needs:", result.buckets.needs.allocated.toFixed(2));
    console.log("Wants:", result.buckets.wants.allocated.toFixed(2));
    console.log("Savings (total):", result.buckets.savings.total.toFixed(2));
    console.log("  ↳ For Future:", result.buckets.savings.forFuture.toFixed(2));
    console.log("  ↳ For Debt:  ", result.buckets.savings.forDebt.toFixed(2));
  });
};

runDebtPriorityTests();
```
Output: 
```
--- Debt Priority: low ---
Needs: 2482.42
Wants: 1427.56
Savings (total): 1090.02
  ↳ For Future: 981.01
  ↳ For Debt:   109.00

--- Debt Priority: medium ---
Needs: 2482.42
Wants: 1327.56
Savings (total): 1190.02
  ↳ For Future: 773.51
  ↳ For Debt:   416.51

--- Debt Priority: high ---
Needs: 2482.42
Wants: 1077.56
Savings (total): 1440.02
  ↳ For Future: 576.01
  ↳ For Debt:   864.01
```