### PR TITLE
[TC 1] Add Savings Preference to Budget Creation

### DIFF
--- a/backend/services/budgetService.js
+++ b/backend/services/budgetService.js
@@ -78,6 +78,11 @@ const adjustBudgetForDebtPriority = (wantsPct, savingsPct, debtPriority) => {
   };
 };
 
+const adjustBudgetForSavingsPriority = (savingsPct, savingsPriority) => {
+  return;
+};
+
+
 const buildBudgetBreakdown = (preferences, recurringTxns) => {
   const { monthlyIncome, debtPriority } = preferences;
 


### PR DESCRIPTION
## Description
- This PR introduces logic to, based on your debt priority, shift the budget to help pay off debt. If debt priority is set to medium or high, we lower your wants slightly and boost savings, then split those savings so some go toward debt.
- Future PRs will add the savings priority to the budget logic.
## Milestone
- Milestone 3, [Issue 58](https://github.com/NancyMetaU/FinanceCompanion/issues/58)
## Resources
- None
## Test Plan
- Used test script to run function and confirm output.
Script:
```
```

Output:
```
```