### PR TITLE
[TC 1] Refactor Spending Focus to Array 

### DIFF
--- a/backend/prisma/migrations/20250711235719_spending_foucs/migration.sql
+++ b/backend/prisma/migrations/20250711235719_spending_foucs/migration.sql
@@ -1,0 +1,9 @@
+/*
+  Warnings:
+
+  - The `spendingFocus` column on the `User` table would be dropped and recreated. This will lead to data loss if there is data in the column.
+
+*/
+-- AlterTable
+ALTER TABLE "User" DROP COLUMN "spendingFocus",
+ADD COLUMN     "spendingFocus" TEXT[] DEFAULT ARRAY[]::TEXT[];

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -22,7 +22,7 @@ model User {
   monthlyIncome   Float?
   savingsPriority String?
   debtPriority    String?
-  spendingFocus   String?
+  spendingFocus   String[] @default([])
 }
 
 model PlaidConnection {

--- a/frontend/src/budget-page-components/BudgetForm.jsx
+++ b/frontend/src/budget-page-components/BudgetForm.jsx
@@ -2,6 +2,7 @@ import React, { useState } from "react";
 import { getAuth } from "firebase/auth";
 import PreferenceRadioGroup from "./PreferenceRadioGroup";
 import ErrorMessage from "../shared-components/ErrorMessage";
+import RankedMultiSelect from "./RankedMultiSelect";
 
 const BACKEND_URL = import.meta.env.VITE_BACKEND_URL;
 
@@ -28,7 +29,7 @@ const BudgetForm = ({ closeModal }) => {
     monthlyIncome: "",
     savingsPriority: "",
     debtPriority: "",
-    spendingFocus: "",
+    spendingFocus: [],
   });
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState("");
@@ -104,12 +105,12 @@ const BudgetForm = ({ closeModal }) => {
         onChange={handleInputChange}
         options={PRIORITY_OPTIONS}
       />
-      <PreferenceRadioGroup
+      <RankedMultiSelect
         name="spendingFocus"
-        label="Where do you like to treat yourself?"
+        options={SPENDING_FOCUS_OPTIONS}
         value={formData.spendingFocus}
         onChange={handleInputChange}
-        options={SPENDING_FOCUS_OPTIONS}
+        label="Top 3 categories you like to treat yourself in"
       />
 
       <div className="flex gap-3 mt-8">

--- a/frontend/src/budget-page-components/RankedMultiSelect.jsx
+++ b/frontend/src/budget-page-components/RankedMultiSelect.jsx
@@ -1,0 +1,69 @@
+const RankedMultiSelect = ({
+  name,
+  options,
+  value,
+  onChange,
+  label,
+  max = 3,
+}) => {
+  const toggleSelection = (optionValue) => {
+    const isSelected = value.includes(optionValue);
+
+    const updated = isSelected
+      ? value.filter((v) => v !== optionValue)
+      : value.length < max
+      ? [...value, optionValue]
+      : value;
+
+    onChange({ target: { name, value: updated } });
+  };
+
+  return (
+    <div className="mb-6">
+      <label className="block text-sm font-medium text-gray-700 mb-3">
+        {label}
+      </label>
+      <div
+        className="flex flex-wrap gap-3"
+        role="group"
+        aria-labelledby={`${name}-label`}
+      >
+        {options.map(({ value: optionValue, label: optionLabel }) => {
+          const selectedIndex = value.indexOf(optionValue);
+          const isSelected = selectedIndex !== -1;
+          const isMaxReached = value.length >= max && !isSelected;
+
+          return (
+            <button
+              type="button"
+              key={optionValue}
+              onClick={() => toggleSelection(optionValue)}
+              disabled={isMaxReached}
+              aria-pressed={isSelected}
+              className={`relative px-4 py-2 rounded-full text-sm font-medium border
+                ${
+                  isSelected
+                    ? "bg-blue-100 border-blue-500 text-blue-700 "
+                    : isMaxReached
+                    ? "bg-gray-100 border-gray-200 text-gray-400 cursor-not-allowed"
+                    : "bg-white border-gray-300 text-gray-700 hover:border-gray-400 cursor-pointer"
+                }`}
+            >
+              {optionLabel}
+              {isSelected && (
+                <span
+                  className="absolute -top-2 -right-2 bg-blue-500 text-white text-xs rounded-full w-5 h-5 flex items-center justify-center"
+                  aria-label={`Priority ${selectedIndex + 1}`}
+                >
+                  {selectedIndex + 1}
+                </span>
+              )}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+
+export default RankedMultiSelect;


### PR DESCRIPTION
## Description
- This PR converts the spending focus form a single string to an array of strings.
- Future PRs will utilize this array to calculate wants allocation
## Milestone
- Milestone 3, [Issue 58](https://github.com/NancyMetaU/FinanceCompanion/issues/58)
## Resources
- None
## Test Plan
<img width="1725" height="864" alt="Screenshot 2025-07-11 at 5 44 56 PM" src="https://github.com/user-attachments/assets/3f7c4df3-5c3c-47f2-b216-b96b116916b5" />