### PR TITLE
[TC 1] Add Functionality for Budget on Frontend

### DIFF
--- a/frontend/src/budget-page-components/BudgetModal.jsx
+++ b/frontend/src/budget-page-components/BudgetModal.jsx
@@ -1,17 +1,22 @@
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/lib/ui/dialog";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/lib/ui/dialog";
 import BudgetForm from "./BudgetForm";
 
-const BudgetModal = ({ open, setOpen }) => {
-    return (
-        <Dialog open={open} onOpenChange={setOpen}>
-            <DialogContent>
-                <DialogHeader>
-                    <DialogTitle>Create Your Budget</DialogTitle>
-                </DialogHeader>
-                <BudgetForm closeModal={() => setOpen(false)} />
-            </DialogContent>
-        </Dialog>
-    );
+const BudgetModal = ({ open, setOpen, onSubmit }) => {
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Create Your Budget</DialogTitle>
+        </DialogHeader>
+        <BudgetForm closeModal={() => setOpen(false)} onSubmit={onSubmit} />
+      </DialogContent>
+    </Dialog>
+  );
 };
 
 export default BudgetModal;

--- a/frontend/src/budget-page-components/CreateBudgetButton.jsx
+++ b/frontend/src/budget-page-components/CreateBudgetButton.jsx
@@ -1,19 +1,18 @@
-import { useState } from 'react';
-import BudgetModal from './BudgetModal';
+import { useState } from "react";
+import BudgetModal from "./BudgetModal";
 
-const CreateBudgetButton = () => {
+const CreateBudgetButton = ({ onBudgetGenerated }) => {
   const [open, setOpen] = useState(false);
 
   return (
     <>
       <button
-        variant="outline"
         onClick={() => setOpen(true)}
         className="text-md font-medium text-royal border border-royal px-4 py-1.5 rounded-md hover:bg-royal hover:text-white transition cursor-pointer"
       >
         Create Budget Plan
       </button>
-      <BudgetModal open={open} setOpen={setOpen} />
+      <BudgetModal open={open} setOpen={setOpen} onSubmit={onBudgetGenerated} />
     </>
   );
 };

--- a/frontend/src/pages/BudgetPage.jsx
+++ b/frontend/src/pages/BudgetPage.jsx
@@ -7,6 +7,7 @@ import PlaidLinkButton from "../budget-page-components/PlaidLinkButton";
 import BankAccountList from "../budget-page-components/BankAccountList";
 import TransactionList from "../budget-page-components/TransactionList";
 import CreateBudgetButton from "../budget-page-components/CreateBudgetButton";
+import BudgetBreakdown from "../budget-page-components/BudgetBreakdown";
 import Loading from "../shared-components/Loading";
 import ErrorMessage from "../shared-components/ErrorMessage";
 
@@ -15,6 +16,7 @@ const BACKEND_URL = import.meta.env.VITE_BACKEND_URL;
 const BudgetPage = () => {
   const [accounts, setAccounts] = useState([]);
   const [transactions, setTransactions] = useState([]);
+  const [budget, setBudget] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
 
@@ -96,8 +98,13 @@ const BudgetPage = () => {
               </section>
 
               <section className="flex justify-center">
-                <CreateBudgetButton />
+                <CreateBudgetButton onBudgetGenerated={setBudget} />
               </section>
+              {budget && (
+                <section className="mt-10">
+                  <BudgetBreakdown budget={budget} />
+                </section>
+              )}
             </>
           )}
         </main>


### PR DESCRIPTION
## Description
- This PR introduces logic to hit GET API for budget calculation in frontend.
- Future PRs will add complete budget components
## Milestone
- Milestone 3, [Issue 59](https://github.com/NancyMetaU/FinanceCompanion/issues/59)
## Resources
- None
## Test Plan
- Ensured budget preferences was updated in backend and simple budget was displayed in frontend.