### PR TITLE
[TC 2] Add Familiarity Score to Digestibility Service

### DIFF
--- a/backend/routes/digestibilityRoutes.js
+++ b/backend/routes/digestibilityRoutes.js
@@ -6,16 +6,16 @@ const {
 
 const router = express.Router();
 
-router.post("/score", verifyFirebaseToken, (req, res) => {
+router.post("/score", verifyFirebaseToken, async (req, res) => {
   try {
+    const userId = req.uid;
     const article = req.body.article;
-    const user = req.body.user || {};
 
     if (!article || !article.title || !article.description) {
       return res.status(400).json({ error: "Missing article content." });
     }
 
-    const result = calculateDigestibilityScore(user, article);
+    const result = await calculateDigestibilityScore(userId, article);
     res.status(200).json(result);
   } catch (err) {
     console.error("Digestibility score error:", err);


### PR DESCRIPTION
## Description
- This PR creates the familiarity score to add to digestibility service.
- Later PRs will layer more user feedback to digestibility service.
## Milestone
- Milestone 4, [Issue 60](https://github.com/NancyMetaU/FinanceCompanion/issues/60)
## Resources
- None
## Test Plan
Script:
```
const context1 = { readTags: { "stocks": 2, "inflation": 1 } };
const context2 = { readTags: { "crypto": 5, "bonds": 2 } };
const context3 = { readTags: {} };
const context4 = { readTags: { "AI": 1, "tech": 1, "startups": 1, "VC": 1 } };

console.log("Test 1 (stocks + inflation):", getFamiliarityBoost(context1, ["stocks", "inflation"]));
console.log("Test 2 (crypto + bonds):", getFamiliarityBoost(context2, ["crypto", "bonds"]));
console.log("Test 3 (empty readTags):", getFamiliarityBoost(context3, ["stocks", "inflation"]));
console.log("Test 4 (AI + tech + startups):", getFamiliarityBoost(context4, ["AI", "tech", "startups"]));
console.log("Test 5 (only inflation):", getFamiliarityBoost(context1, ["inflation"]));
console.log("Test 6 (tag not in readTags):", getFamiliarityBoost(context1, ["real estate"])); 
```

Output:
```
Test 1 (stocks + inflation): 15
Test 2 (crypto + bonds): 15
Test 3 (empty readTags): 0
Test 4 (AI + tech + startups): 15
Test 5 (only inflation): 5
Test 6 (tag not in readTags): 0
```