### PR TITLE
[TC 2] Add Time Spent Upper Limit

### DIFF
--- a/backend/services/digestibilityService.js
+++ b/backend/services/digestibilityService.js
@@ -178,7 +178,7 @@ function getSimilarityTimeSpentPenalty(userContext, article) {
 
   const allReadSeconds = readArticles
     .map((a) => toSeconds(a.timeSpent))
-    .filter((t) => t > 0);
+    .filter((t) => t > 0 && t <= 120 * 60);
 
   if (allReadSeconds.length < 2) return 0;
 
@@ -189,7 +189,7 @@ function getSimilarityTimeSpentPenalty(userContext, article) {
     .map((sim) =>
       toSeconds(readArticles.find((a) => a.id === sim.uuid)?.timeSpent || 0)
     )
-    .filter((t) => t > 0);
+    .filter((t) => t > 0 && t <= 120 * 60);
 
   if (!similarReadSeconds.length) return 0;
 


### PR DESCRIPTION
## Description
- This PR creates a function to ensure an abnormally large time spent is not used to calculate the penalty. We check by eliminating all times over 2 hours.
## Milestone
- Milestone 4, [Issue 60](https://github.com/NancyMetaU/FinanceCompanion/issues/60)
## Resources
- None
## Test Plan
- Ensure scripts run correctly from https://github.com/NancyMetaU/FinanceCompanion/pull/106