### PR TITLE
[TC 2] Implement Session Caching

### DIFF
--- a/frontend/src/pages/NewsPage.jsx
+++ b/frontend/src/pages/NewsPage.jsx
@@ -20,15 +20,24 @@ const NewsPage = () => {
     const getNews = async () => {
       try {
         setIsLoading(true);
+
+        const cached = sessionStorage.getItem("newsArticles");
+        if (cached) {
+          setArticles(JSON.parse(cached));
+          return;
+        }
+
         const response = await fetch(`${BACKEND_URL}/api/news/`);
         if (!response.ok) throw new Error(`Error ${response.status}`);
 
         const apiArticles = await response.json();
-        setArticles([...apiArticles, ...fallbackNewsData]);
+        const merged = [...apiArticles, ...fallbackNewsData];
+
+        sessionStorage.setItem("newsArticles", JSON.stringify(merged));
+        setArticles(merged);
       } catch (err) {
         console.error("Error fetching news:", err);
         setError(err.message || "Failed to load news articles");
-
         setArticles(fallbackNewsData);
       } finally {
         setIsLoading(false);


### PR DESCRIPTION
## Description
- This PR caches fetched news articles in sessionStorage to avoid repeated API calls during the same session. (API Limit per day = 100) 
## Milestone
- Milestone 4, [Issue 60](https://github.com/NancyMetaU/FinanceCompanion/issues/60)
## Resources
- [Stack-overflow sessionStorage Explanation](https://stackoverflow.com/questions/73019223/react-sessionstorage-vs-localstorage-vs-cache)
- [Mozilla sessionStorage Doc](https://developer.mozilla.org/en-US/docs/Web/API/Window/sessionStorage)
## Test Plan
- Ensure on page reload the API hit count is not increased but rather when tab is closed and page is rerendered.