### PR TITLE
[TC 2] Reload Digestibility Score on User Interactions

### DIFF
--- a/frontend/src/news-page-components/Article.jsx
+++ b/frontend/src/news-page-components/Article.jsx
@@ -6,7 +6,7 @@ import FeedbackModal from "./FeedbackModal";
 
 const BACKEND_URL = import.meta.env.VITE_BACKEND_URL;
 
-const Article = ({ article }) => {
+const Article = ({ article, onDigestibilityChange }) => {
   const [isRead, setIsRead] = useState(false);
   const [isFeedbackModalOpen, setIsFeedbackModalOpen] = useState(false);
 
@@ -16,7 +16,7 @@ const Article = ({ article }) => {
     return await user.getIdToken();
   };
 
-  const markAsRead = async (timeSpentSeconds = null) => {
+  const markAsRead = async (timeSpentSeconds = 0) => {
     try {
       const idToken = await getCurrentUserToken();
       const articleData = {
@@ -37,6 +37,7 @@ const Article = ({ article }) => {
       if (!response.ok)
         throw new Error(`Server responded with status: ${response.status}`);
       setIsRead(true);
+      if (onDigestibilityChange) onDigestibilityChange();
     } catch (error) {
       console.error("Error marking article as read:", error);
     }
@@ -58,6 +59,7 @@ const Article = ({ article }) => {
       if (!response.ok)
         throw new Error(`Server responded with status: ${response.status}`);
       setIsRead(false);
+      if (onDigestibilityChange) onDigestibilityChange();
     } catch (error) {
       console.error("Error unmarking article as read:", error);
     }
@@ -81,6 +83,7 @@ const Article = ({ article }) => {
           const timeSpentSeconds = Math.floor(timeSpentMs / 1000);
 
           markAsRead(timeSpentSeconds);
+          if (onDigestibilityChange) onDigestibilityChange();
         }
       }, 500);
     } else {
@@ -196,6 +199,7 @@ const Article = ({ article }) => {
         isOpen={isFeedbackModalOpen}
         onClose={() => setIsFeedbackModalOpen(false)}
         article={article}
+        onDigestibilityChange={onDigestibilityChange}
       />
     </article>
   );

--- a/frontend/src/news-page-components/ArticleGrid.jsx
+++ b/frontend/src/news-page-components/ArticleGrid.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import Article from "./Article";
 
-const ArticleGrid = ({ articles }) => {
+const ArticleGrid = ({ articles, onDigestibilityChange }) => {
   const validArticles = articles?.filter((article) => article.uuid) || [];
 
   if (validArticles.length === 0) {
@@ -17,7 +17,10 @@ const ArticleGrid = ({ articles }) => {
       <ul className="grid gap-6 sm:grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 list-none p-0">
         {validArticles.map((article) => (
           <li key={article.uuid}>
-            <Article article={article} />
+            <Article
+              article={article}
+              onDigestibilityChange={onDigestibilityChange}
+            />
           </li>
         ))}
       </ul>

--- a/frontend/src/news-page-components/FeedbackModal.jsx
+++ b/frontend/src/news-page-components/FeedbackModal.jsx
@@ -13,7 +13,7 @@ import Loading from "../shared-components/Loading";
 
 const BACKEND_URL = import.meta.env.VITE_BACKEND_URL;
 
-const FeedbackModal = ({ isOpen, onClose, article }) => {
+const FeedbackModal = ({ isOpen, onClose, article, onDigestibilityChange }) => {
   const [rating, setRating] = useState(0);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState("");
@@ -56,6 +56,7 @@ const FeedbackModal = ({ isOpen, onClose, article }) => {
       }
 
       setSuccess(true);
+      if (onDigestibilityChange) onDigestibilityChange();
     } catch (error) {
       console.error("Error submitting feedback:", error);
       setError(error.message);

--- a/frontend/src/pages/NewsPage.jsx
+++ b/frontend/src/pages/NewsPage.jsx
@@ -13,6 +13,8 @@ const BACKEND_URL = import.meta.env.VITE_BACKEND_URL;
 const NewsPage = () => {
   const [articles, setArticles] = useState([]);
   const [digestibilityScores, setDigestibilityScores] = useState({});
+  const [digestibilityRefreshTrigger, setDigestibilityRefreshTrigger] =
+    useState(0);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState(null);
 
@@ -103,7 +105,7 @@ const NewsPage = () => {
     };
 
     fetchDigestibilityScores();
-  }, [articles]);
+  }, [articles, digestibilityRefreshTrigger]);
 
   return (
     <div className="flex flex-col min-h-screen">
@@ -121,6 +123,9 @@ const NewsPage = () => {
                 ...article,
                 digestibility: digestibilityScores[article.uuid] || null,
               }))}
+              onDigestibilityChange={() =>
+                setDigestibilityRefreshTrigger((prev) => prev + 1)
+              }
             />
           )}
         </main>


### PR DESCRIPTION
## Description
- This PR ensures when an article's context is updated, the digestibility scores of all cards is re-rendered/calculated.
## Milestone
- Milestone 4, [Issue 60](https://github.com/NancyMetaU/FinanceCompanion/issues/60)
## Resources
- Insomnia output of article helped during debugging session with Noah to find inconsistent article structure being passed into familiarity boost of algorithm. (article.industry should be article.entities[0].industry)
## Test Plan

https://github.com/user-attachments/assets/ebf4fb02-ad5c-410d-8980-e393858a2104

