### PR TITLE
[TC 1] Add Employment Type on Budget Form

### DIFF
--- a/frontend/src/budget-page-components/BudgetForm.jsx
+++ b/frontend/src/budget-page-components/BudgetForm.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import { getAuth } from "firebase/auth";
 import PreferenceRadioGroup from "./PreferenceRadioGroup";
+import EmploymentTypeRadioGroup from "./EmploymentTypeRadioGroup";
 import ErrorMessage from "../shared-components/ErrorMessage";
 import RankedMultiSelect from "./RankedMultiSelect";
 
@@ -27,6 +28,7 @@ const SPENDING_FOCUS_OPTIONS = [
 const BudgetForm = ({ closeModal, onSubmit }) => {
   const [formData, setFormData] = useState({
     monthlyIncome: "",
+    employmentType: "",
     savingsPriority: "",
     debtPriority: "",
     spendingFocus: [],
@@ -55,6 +57,7 @@ const BudgetForm = ({ closeModal, onSubmit }) => {
         },
         body: JSON.stringify({
           monthlyIncome: parseFloat(formData.monthlyIncome),
+          employmentType: formData.employmentType,
           savingsPriority: formData.savingsPriority,
           debtPriority: formData.debtPriority,
           spendingFocus: formData.spendingFocus,
@@ -113,6 +116,13 @@ const BudgetForm = ({ closeModal, onSubmit }) => {
           required
         />
       </div>
+
+      <EmploymentTypeRadioGroup
+        name="employmentType"
+        label="Employment Type"
+        value={formData.employmentType}
+        onChange={handleInputChange}
+      />
 
       <PreferenceRadioGroup
         name="savingsPriority"

--- a/frontend/src/budget-page-components/BudgetForm.jsx
+++ b/frontend/src/budget-page-components/BudgetForm.jsx
@@ -103,7 +103,7 @@ const BudgetForm = ({ closeModal, onSubmit }) => {
           htmlFor="monthlyIncome"
           className="block text-sm font-medium text-gray-700 mb-2"
         >
-          Monthly Income ($)
+          Monthly Income (pre-tax)
         </label>
         <input
           id="monthlyIncome"
@@ -112,7 +112,7 @@ const BudgetForm = ({ closeModal, onSubmit }) => {
           value={formData.monthlyIncome}
           onChange={handleInputChange}
           className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500"
-          placeholder="Enter your monthly income"
+          placeholder="Enter your monthly income ($)"
           required
         />
       </div>

--- a/frontend/src/budget-page-components/EmploymentTypeRadioGroup.jsx
+++ b/frontend/src/budget-page-components/EmploymentTypeRadioGroup.jsx
@@ -1,0 +1,39 @@
+import { RadioGroup, RadioGroupItem } from "../lib/ui/radio-group";
+
+const EmploymentTypeRadioGroup = ({ name, value, onChange, label }) => {
+  const options = [
+    { value: "freelancer", label: "I'm a freelancer or self-employed" },
+    { value: "w2", label: "I receive a regular paycheck (W-2)" },
+  ];
+
+  return (
+    <div className="mb-6">
+      <label className="block text-sm font-medium text-gray-700 mb-3">
+        {label}
+      </label>
+      <RadioGroup
+        value={value}
+        onValueChange={(newValue) =>
+          onChange({ target: { name, value: newValue } })
+        }
+        className="flex flex-col gap-3"
+      >
+        {options.map((option) => (
+          <label
+            key={option.value}
+            className={`flex items-center justify-center px-4 py-2 rounded-full border-2 cursor-pointer ${
+              value === option.value
+                ? "border-blue-500 bg-blue-50 text-blue-700"
+                : "border-gray-300 bg-white text-gray-700 hover:border-gray-400"
+            }`}
+          >
+            <RadioGroupItem value={option.value} className="sr-only" />
+            <span className="text-sm font-medium">{option.label}</span>
+          </label>
+        ))}
+      </RadioGroup>
+    </div>
+  );
+};
+
+export default EmploymentTypeRadioGroup;


### PR DESCRIPTION
## Description
- This PR adds a new question to the budget form regarding employment type.
- Future PRs will use this employment type to determine tax breakdown and which bucket the expense will go in. (ex. If w2 employee, taxes will be placed under needs. This represents taxes taken from paychecks.)
## Milestone
- Milestone 3, [Issue 58](https://github.com/NancyMetaU/FinanceCompanion/issues/58)
## Resources
- [ShadCn Radio Group Documentation](https://ui.shadcn.com/docs/components/radio-group)
## Test Plan
<img width="620" height="740" alt="Screenshot 2025-07-23 at 4 20 20 PM" src="https://github.com/user-attachments/assets/1d89bd39-6112-451b-81c2-3c9ef6cfecf9" />

