### PR TITLE
[TC 1] Add Employment Field to User Table

### DIFF
--- a/backend/prisma/migrations/20250723232428_employement_type/migration.sql
+++ b/backend/prisma/migrations/20250723232428_employement_type/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "employmentType" TEXT;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -20,6 +20,7 @@ model User {
   updatedAt       DateTime @updatedAt
 
   monthlyIncome   Float?
+  employmentType  String?
   savingsPriority String?
   debtPriority    String?
   spendingFocus   String[] @default([])

--- a/backend/routes/userRoutes.js
+++ b/backend/routes/userRoutes.js
@@ -21,12 +21,13 @@ router.post("/init", verifyFirebaseToken, async (req, res) => {
 
 router.post("/preferences", verifyFirebaseToken, async (req, res) => {
   const userId = req.uid;
-  const { monthlyIncome, savingsPriority, debtPriority, spendingFocus } =
+  const { monthlyIncome, employmentType, savingsPriority, debtPriority, spendingFocus } =
     req.body;
 
   try {
     const updatedUser = await updateUserPreferences(userId, {
       monthlyIncome,
+      employmentType,
       savingsPriority,
       debtPriority,
       spendingFocus,

--- a/backend/services/userService.js
+++ b/backend/services/userService.js
@@ -15,6 +15,7 @@ const updateUserPreferences = async (id, preferences) => {
     where: { id },
     data: {
       monthlyIncome: preferences.monthlyIncome,
+      employmentType: preferences.employmentType,
       savingsPriority: preferences.savingsPriority,
       debtPriority: preferences.debtPriority,
       spendingFocus: preferences.spendingFocus,
@@ -27,6 +28,7 @@ const getUserPreferences = async (id) => {
     where: { id },
     select: {
       monthlyIncome: true,
+      employmentType: true,
       savingsPriority: true,
       debtPriority: true,
       spendingFocus: true,


### PR DESCRIPTION
## Description
- This PR adds a employment type field to User table and routes
- Future PRs will use this employment type to determine tax breakdown and which bucket the expense will go in. (ex. If w2 employee, taxes will be placed under needs. This represents taxes taken from paychecks.)
## Milestone
- Milestone 3, [Issue 58](https://github.com/NancyMetaU/FinanceCompanion/issues/58)
## Resources
- None
## Test Plan
<img width="1460" height="78" alt="Screenshot 2025-07-23 at 4 29 25 PM" src="https://github.com/user-attachments/assets/97bda98b-bbad-4f8c-a983-31dc70b2d08c" />
