### PR TITLE
[TC 1] Add Debt Loan Breakdown

### DIFF
--- a/backend/services/bankAccountService.js
+++ b/backend/services/bankAccountService.js
@@ -60,38 +60,24 @@ const getTotalDebt = async (userId) => {
     where: {
       userId,
       OR: [
-        { type: "credit" },
         { type: "loan" },
         {
           subtype: {
-            in: [
-              "credit card",
-              "paypal",
-              "mortgage",
-              "student",
-              "auto",
-              "business",
-              "commercial",
-              "construction",
-            ],
+            in: ["mortgage", "student", "auto"],
           },
         },
       ],
     },
   });
 
-  const breakdown = debtAccounts.map((acc) => {
-    const interestRate = DEFAULT_INTEREST_RATES[acc.subtype] || null;
-
-    return {
-      id: acc.id,
-      name: acc.name,
-      type: acc.type,
-      subtype: acc.subtype,
-      balance: acc.balance,
-      interestRate,
-    };
-  });
+  const breakdown = debtAccounts.map((acc) => ({
+    id: acc.id,
+    name: acc.name,
+    type: acc.type,
+    subtype: acc.subtype,
+    balance: acc.balance,
+    interestRate: DEFAULT_INTEREST_RATES[acc.subtype] || null,
+  }));
 
   const total = breakdown.reduce((sum, acc) => sum + (acc.balance || 0), 0);
 


### PR DESCRIPTION
## Description
- This PR adds logic to retrieve all loan accounts from the user's account details and calculate how much of the debt bucket should be allocated to each, based on default interest rates.
## Milestone
- Milestone 3, [Issue 58](https://github.com/NancyMetaU/FinanceCompanion/issues/58)
## Resources
- None 
## Test Plan
- Upon budget creation, forDebt object appears as:
```
 "forDebt": {
        "total": 302.9632898951996,
        "accounts": [
          {
            "id": "cmde11z740005z2eaioda854a",
            "name": "Plaid Student Loan",
            "type": "loan",
            "balance": 65262,
            "subtype": "student",
            "interestRate": 0.055,
            "suggestedPayment": 299.1175
          },
          {
            "id": "cmde11z78000bz2ear0sx20gl",
            "name": "Plaid Mortgage",
            "type": "loan",
            "balance": 56302.06,
            "subtype": "mortgage",
            "interestRate": 0.04,
            "suggestedPayment": 187.6735333333333
          }
        ]
      },
```